### PR TITLE
Update copyright header to OpenSSF Contributors.

### DIFF
--- a/jobs/docker-scanner/Dockerfile
+++ b/jobs/docker-scanner/Dockerfile
@@ -1,3 +1,6 @@
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
+
 FROM ubuntu:20.04
 
 LABEL schema-version="1.0"

--- a/jobs/docker-scanner/__init__.py
+++ b/jobs/docker-scanner/__init__.py
@@ -1,0 +1,2 @@
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.

--- a/jobs/docker-scanner/orchestrator.py
+++ b/jobs/docker-scanner/orchestrator.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
 
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
+
+
 import json
 import logging
 import os

--- a/jobs/docker-scanner/processors/__init__.py
+++ b/jobs/docker-scanner/processors/__init__.py
@@ -1,5 +1,6 @@
-# Copyright (c) Microsoft Corporation.
-# Licensed under the MIT License.
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
+
 import json
 import logging
 import os

--- a/jobs/docker-scanner/processors/characteristics.py
+++ b/jobs/docker-scanner/processors/characteristics.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
-# Copyright (c) Microsoft Corporation.
-# Licensed under the MIT License.
+
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
 
 import argparse
 import json

--- a/jobs/docker-scanner/processors/cii_badge_data.py
+++ b/jobs/docker-scanner/processors/cii_badge_data.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
-# Copyright (c) Microsoft Corporation.
-# Licensed under the MIT License.
+
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
 
 import argparse
 import json

--- a/jobs/docker-scanner/processors/fastsquat.py
+++ b/jobs/docker-scanner/processors/fastsquat.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
-# Copyright (c) Microsoft Corporation.
-# Licensed under the MIT License.
+
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
 
 import argparse
 import json

--- a/jobs/docker-scanner/processors/github_pr_approval.py
+++ b/jobs/docker-scanner/processors/github_pr_approval.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
-# Copyright (c) Microsoft Corporation.
-# Licensed under the MIT License.
+
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
 
 import argparse
 import json

--- a/jobs/docker-scanner/processors/languageanalyzability.py
+++ b/jobs/docker-scanner/processors/languageanalyzability.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
-# Copyright (c) Microsoft Corporation.
-# Licensed under the MIT License.
+
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
 
 import argparse
 import json

--- a/src/core/__init__.py
+++ b/src/core/__init__.py
@@ -1,0 +1,2 @@
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.

--- a/src/core/asgi.py
+++ b/src/core/asgi.py
@@ -1,3 +1,6 @@
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
+
 """
 ASGI config for core project.
 

--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -1,3 +1,6 @@
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
+
 """
 Global Settings
 

--- a/src/core/urls.py
+++ b/src/core/urls.py
@@ -1,3 +1,6 @@
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
+
 """core URL Configuration
 
 The `urlpatterns` list routes URLs to views. For more information please see:

--- a/src/core/wsgi.py
+++ b/src/core/wsgi.py
@@ -1,3 +1,6 @@
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
+
 """
 WSGI config for core project.
 

--- a/src/manage.py
+++ b/src/manage.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
+
+
 """Django's command-line utility for administrative tasks."""
 import os
 import sys

--- a/src/oss/__init__.py
+++ b/src/oss/__init__.py
@@ -1,1 +1,4 @@
-default_app_config = 'oss.apps.OssConfig'
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
+
+default_app_config = "oss.apps.OssConfig"

--- a/src/oss/admin.py
+++ b/src/oss/admin.py
@@ -1,2 +1,2 @@
-
-# Register your models here.
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.

--- a/src/oss/apps.py
+++ b/src/oss/apps.py
@@ -1,5 +1,5 @@
-# Copyright (c) Microsoft Corporation.
-# Licensed under the MIT License.
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
 
 import logging
 

--- a/src/oss/forms/__init__.py
+++ b/src/oss/forms/__init__.py
@@ -1,0 +1,2 @@
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.

--- a/src/oss/forms/article.py
+++ b/src/oss/forms/article.py
@@ -1,5 +1,7 @@
-from django import forms
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
 
+from django import forms
 from oss.models.article import ArticleRevision
 
 

--- a/src/oss/jobs/active_maintainers.py
+++ b/src/oss/jobs/active_maintainers.py
@@ -1,13 +1,15 @@
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
+
 import datetime
 import logging
 
+from core.settings import GITHUB_TOKENS
 from django.utils import timezone
 from github import Github
-from packageurl import PackageURL
-
-from core.settings import GITHUB_TOKENS
 from oss.models.component import Component
 from oss.models.mixins import MetadataType
+from packageurl import PackageURL
 
 from . import BaseJob
 

--- a/src/oss/jobs/typo_squatting.py
+++ b/src/oss/jobs/typo_squatting.py
@@ -1,16 +1,18 @@
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
+
 import datetime
 import logging
 import urllib
 from typing import Dict, List
 
 import requests
+from core.settings import FASTSQUAT_API_ENDPOINT, FASTSQUAT_API_TOKEN
 from django.utils import timezone
 from github import Github
-from packageurl import PackageURL
-
-from core.settings import FASTSQUAT_API_ENDPOINT, FASTSQUAT_API_TOKEN
 from oss.models.component import Component
 from oss.models.mixins import MetadataType
+from packageurl import PackageURL
 
 from . import BaseJob
 

--- a/src/oss/management/commands/import_cve_database.py
+++ b/src/oss/management/commands/import_cve_database.py
@@ -1,5 +1,5 @@
-# Copyright (c) Microsoft Corporation.
-# Licensed under the MIT License.
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
 
 """
 Imports the CVE database from NIST.

--- a/src/oss/models/article.py
+++ b/src/oss/models/article.py
@@ -1,5 +1,5 @@
-# Copyright (c) Microsoft Corporation.
-# Licensed under the MIT License.
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
 
 """
 An article.

--- a/src/oss/models/artifact.py
+++ b/src/oss/models/artifact.py
@@ -1,5 +1,5 @@
-# Copyright (c) Microsoft Corporation.
-# Licensed under the MIT License.
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
 
 """
 A release artifact for an open source component.

--- a/src/oss/models/component.py
+++ b/src/oss/models/component.py
@@ -1,5 +1,5 @@
-# Copyright (c) Microsoft Corporation.
-# Licensed under the MIT License.
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
 
 """
 An open source component.

--- a/src/oss/models/cve.py
+++ b/src/oss/models/cve.py
@@ -1,5 +1,5 @@
-# Copyright (c) Microsoft Corporation.
-# Licensed under the MIT License.
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
 
 """
 Data related to CVEs

--- a/src/oss/models/maintainer.py
+++ b/src/oss/models/maintainer.py
@@ -1,5 +1,5 @@
-# Copyright (c) Microsoft Corporation.
-# Licensed under the MIT License.
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
 
 import enum
 import uuid

--- a/src/oss/models/mixins.py
+++ b/src/oss/models/mixins.py
@@ -1,5 +1,5 @@
-# Copyright (c) Microsoft Corporation.
-# Licensed under the MIT License.
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
 
 import datetime
 from enum import Enum

--- a/src/oss/models/reviews.py
+++ b/src/oss/models/reviews.py
@@ -1,5 +1,5 @@
-# Copyright (c) Microsoft Corporation.
-# Licensed under the MIT License.
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
 
 import logging
 import uuid

--- a/src/oss/models/url.py
+++ b/src/oss/models/url.py
@@ -1,5 +1,5 @@
-# Copyright (c) Microsoft Corporation.
-# Licensed under the MIT License.
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
 
 import logging
 import uuid

--- a/src/oss/models/version.py
+++ b/src/oss/models/version.py
@@ -1,5 +1,5 @@
-# Copyright (c) Microsoft Corporation.
-# Licensed under the MIT License.
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
 
 """
 A version of an open source component.

--- a/src/oss/serializers/serializers.py
+++ b/src/oss/serializers/serializers.py
@@ -1,5 +1,5 @@
-# Copyright (c) Microsoft Corporation.
-# Licensed under the MIT License.
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
 
 """
 Serialization handlers (Django REST Framework)

--- a/src/oss/templatetags/component_helpers.py
+++ b/src/oss/templatetags/component_helpers.py
@@ -1,5 +1,5 @@
-# Copyright (c) Microsoft Corporation.
-# Licensed under the MIT License.
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
 
 """
 This module contains common Django template tags.

--- a/src/oss/tests.py
+++ b/src/oss/tests.py
@@ -1,2 +1,2 @@
-
-# Create your tests here.
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.

--- a/src/oss/urls.py
+++ b/src/oss/urls.py
@@ -1,3 +1,6 @@
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
+
 from django.urls import include, path
 from rest_framework import routers
 

--- a/src/oss/utils/__init__.py
+++ b/src/oss/utils/__init__.py
@@ -1,0 +1,2 @@
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.

--- a/src/oss/utils/collections.py
+++ b/src/oss/utils/collections.py
@@ -1,5 +1,5 @@
-# Copyright (c) Microsoft Corporation.
-# Licensed under the MIT License.
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
 
 """
 Helper methods related to collections.

--- a/src/oss/utils/component_importers/__init__.py
+++ b/src/oss/utils/component_importers/__init__.py
@@ -1,3 +1,6 @@
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
+
 from .github_importer import GitHubImporter
 from .npm_importer import NPMImporter
 from .pypi_importer import PyPIImporter

--- a/src/oss/utils/component_importers/base_importer.py
+++ b/src/oss/utils/component_importers/base_importer.py
@@ -1,3 +1,6 @@
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
+
 import copy
 
 

--- a/src/oss/utils/component_importers/converters.py
+++ b/src/oss/utils/component_importers/converters.py
@@ -1,3 +1,6 @@
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
+
 import logging
 import re
 

--- a/src/oss/utils/component_importers/github_importer.py
+++ b/src/oss/utils/component_importers/github_importer.py
@@ -1,3 +1,6 @@
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
+
 """
 Imports a NPM project into OpenSSFMetric
 """
@@ -11,8 +14,6 @@ from urllib.parse import urlparse
 import pytz
 from django.utils import timezone
 from github import Github, GitRelease, Repository
-from packageurl import PackageURL
-
 from oss.models.artifact import Artifact, ArtifactType
 from oss.models.component import Component
 from oss.models.maintainer import Maintainer, MaintainerType
@@ -22,6 +23,7 @@ from oss.models.version import ComponentVersion
 from oss.utils.collections import get_complex
 from oss.utils.component_importers.base_importer import BaseImporter
 from oss.utils.network_helpers import check_url
+from packageurl import PackageURL
 
 logger = logging.getLogger(__name__)
 

--- a/src/oss/utils/component_importers/npm_importer.py
+++ b/src/oss/utils/component_importers/npm_importer.py
@@ -1,3 +1,6 @@
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
+
 """
 Imports a NPM project into OpenSSFMetric
 """

--- a/src/oss/utils/component_importers/pypi_importer.py
+++ b/src/oss/utils/component_importers/pypi_importer.py
@@ -1,3 +1,6 @@
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
+
 """
 Imports a PyPI project into OpenSSFMetric
 """
@@ -6,8 +9,6 @@ import logging
 
 import requests
 from dateutil.parser import isoparse
-from packageurl import PackageURL
-
 from oss.models.artifact import Artifact, ArtifactType
 from oss.models.component import Component
 from oss.models.maintainer import Maintainer, MaintainerType
@@ -17,6 +18,7 @@ from oss.models.version import ComponentVersion
 from oss.utils.collections import get_complex
 from oss.utils.component_importers.base_importer import BaseImporter
 from oss.utils.network_helpers import check_url
+from packageurl import PackageURL
 
 logger = logging.getLogger(__name__)
 

--- a/src/oss/utils/gravatar.py
+++ b/src/oss/utils/gravatar.py
@@ -1,5 +1,5 @@
-# Copyright (c) Microsoft Corporation.
-# Licensed under the MIT License.
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
 
 """
 Utilities related to gravatar.com.

--- a/src/oss/utils/job_queue.py
+++ b/src/oss/utils/job_queue.py
@@ -1,3 +1,6 @@
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
+
 import logging
 from os import getenv
 from typing import Union

--- a/src/oss/utils/metric_evaluators/__init__.py
+++ b/src/oss/utils/metric_evaluators/__init__.py
@@ -1,0 +1,2 @@
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.

--- a/src/oss/utils/network_helpers.py
+++ b/src/oss/utils/network_helpers.py
@@ -1,5 +1,5 @@
-# Copyright (c) Microsoft Corporation.
-# Licensed under the MIT License.
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
 
 """
 Helper methods related to network activity.

--- a/src/oss/utils/purl_helpers.py
+++ b/src/oss/utils/purl_helpers.py
@@ -1,5 +1,5 @@
-# Copyright (c) Microsoft Corporation.
-# Licensed under the MIT License.
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
 
 """
 Helper functions for interacting with PackageURLs.

--- a/src/oss/views/__init__.py
+++ b/src/oss/views/__init__.py
@@ -1,0 +1,2 @@
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.

--- a/src/oss/views/api.py
+++ b/src/oss/views/api.py
@@ -1,5 +1,5 @@
-# Copyright (c) Microsoft Corporation.
-# Licensed under the MIT License.
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
 
 from django.http import (
     HttpRequest,

--- a/src/oss/views/article.py
+++ b/src/oss/views/article.py
@@ -1,5 +1,5 @@
-# Copyright (c) Microsoft Corporation.
-# Licensed under the MIT License.
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
 
 import logging
 from uuid import UUID

--- a/src/oss/views/component.py
+++ b/src/oss/views/component.py
@@ -1,5 +1,5 @@
-# Copyright (c) Microsoft Corporation.
-# Licensed under the MIT License.
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
 
 """
 Views related to a Component.

--- a/src/oss/views/home.py
+++ b/src/oss/views/home.py
@@ -1,9 +1,11 @@
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
+
 import logging
 
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render
 from django.views.decorators.http import require_http_methods
-
 from oss.models.article import Article
 from oss.models.component import Component
 

--- a/src/oss/views/maintainer.py
+++ b/src/oss/views/maintainer.py
@@ -1,5 +1,5 @@
-# Copyright (c) Microsoft Corporation.
-# Licensed under the MIT License.
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
 
 """
 Views related to a Component.

--- a/src/oss/views/review.py
+++ b/src/oss/views/review.py
@@ -1,5 +1,5 @@
-# Copyright (c) Microsoft Corporation.
-# Licensed under the MIT License.
+# Copyright Contributors to the OpenSSF project
+# Licensed under the Apache License.
 
 """
 Views related to a Review.


### PR DESCRIPTION
This PR updates copyright header for source files to OpenSSF Contributors.
It also adds a reference to the Apache license.

Fixes #19.